### PR TITLE
SlipTime

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -517,3 +517,48 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 944ed6f1214f64a4d9b52dedb342569f, type: 3}
+--- !u!1 &2101260595
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2101260597}
+  - component: {fileID: 2101260596}
+  m_Layer: 0
+  m_Name: SlipTime
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2101260596
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2101260595}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cc34c8221dc223745b10af2def13a150, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  slipTimeScalar: 0.25
+  slipTimeDuration: 3
+--- !u!4 &2101260597
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2101260595}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 1.5168587, y: -1.5997268, z: 0.14823195}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scripts/BulletManagement/Bullet.cs
+++ b/Assets/Scripts/BulletManagement/Bullet.cs
@@ -19,11 +19,7 @@ namespace BulletManagement
         private int bulletId;
 
         // Getter and Setters
-        public int BulletId 
-        {
-            get { return this.bulletId; } 
-            private set { this.bulletId = value; }
-        }
+        public int BulletId => this.bulletId;
 
         void OnBecameInvisible() {
             Destroy(this.gameObject);
@@ -37,7 +33,7 @@ namespace BulletManagement
         void Update()
         {
             // When speeding up bullet, the input needs to be multipled and also the derivative is multiplied.
-            timeAlive += Time.deltaTime * emitter.bulletSpeedMultiplier;
+            timeAlive += Time.deltaTime * emitter.bulletSpeedMultiplier * emitter.SlipTimeCoefficient;
 
             // Need to keep track of time so that slo-motion will effect decay as well.
             if (decayTime != 0 && timeAlive >= decayTime)
@@ -50,7 +46,7 @@ namespace BulletManagement
             Vector3 translation = this.bulletPattern.GetTranslation(timeAlive, this.bulletId) * Time.deltaTime;
 
             // Move the actual bullet.
-            transform.Translate(translation * emitter.bulletSpeedMultiplier);
+            transform.Translate(translation * (emitter.bulletSpeedMultiplier * emitter.SlipTimeCoefficient));
         }
 
         public virtual void SetData(Emitter emitter, BulletPattern bulletPattern, int bulletId)

--- a/Assets/Scripts/BulletManagement/Bullet.cs
+++ b/Assets/Scripts/BulletManagement/Bullet.cs
@@ -32,7 +32,8 @@ namespace BulletManagement
 
         void Update()
         {
-            // When speeding up bullet, the input needs to be multipled and also the derivative is multiplied.
+            // When speeding up bullet, the input needs to be multiplied and also the derivative is multiplied.
+            // Speed and SlipTime modifiers should all come from the emitter.
             timeAlive += Time.deltaTime * emitter.bulletSpeedMultiplier * emitter.SlipTimeCoefficient;
 
             // Need to keep track of time so that slo-motion will effect decay as well.
@@ -45,7 +46,7 @@ namespace BulletManagement
             // Optimize this call if need be when we hit optimization issues.
             Vector3 translation = this.bulletPattern.GetTranslation(timeAlive, this.bulletId) * Time.deltaTime;
 
-            // Move the actual bullet.
+            // Move the actual bullet. Speed and SlipTime modifiers should all come from the emitter.
             transform.Translate(translation * (emitter.bulletSpeedMultiplier * emitter.SlipTimeCoefficient));
         }
 

--- a/Assets/Scripts/BulletManagement/BulletPattern.cs
+++ b/Assets/Scripts/BulletManagement/BulletPattern.cs
@@ -20,8 +20,8 @@ namespace BulletManagement
 
         /// <summary>
         /// Calculates translation when given time t of the lifetime
-        // of an object from float. bulletId is used if each bullet
-        // needs to have unique patterns.
+        /// of an object from float. bulletId is used if each bullet
+        /// needs to have unique patterns.
         /// </summary>
         /// <param name="time">time in double precision. Usually Time.deltaTime.</param>
         /// <param name="bulletId">Unique bullet ID assigned for each ejected group of bullets.</param>

--- a/Assets/Scripts/BulletManagement/Emitter.cs
+++ b/Assets/Scripts/BulletManagement/Emitter.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using SlipTime;
+using UnityEngine;
 
 namespace BulletManagement
 {
@@ -7,12 +8,13 @@ namespace BulletManagement
     * Each bullet is responsible for knowing what speed it should go
     * as each GameObject must be updated by Unity so this is the most effective.
     */
-    public class Emitter : MonoBehaviour
+    public class Emitter : SlipTimeAdherent
     {
         // Will attempt to get BulletPattern on object at program start.
         private BulletPattern bulletPattern;
 
         public float bulletSpeedMultiplier = 1.0f;
+        
         public GameObject bulletPrefab;
 
         public double timeCounter = 0.0;
@@ -40,15 +42,16 @@ namespace BulletManagement
             }
         }
 
-        void Start()
+        private void Start()
         {
+            this.SlipTimeCoefficient = 1.0f;
             this.bulletPattern = this.GetComponent<BulletPattern>();
         }
 
         // Update is called once per frame
         void Update()
         {
-            timeCounter += Time.deltaTime * bulletSpeedMultiplier;
+            timeCounter += Time.deltaTime * bulletSpeedMultiplier * SlipTimeCoefficient;
             if (timeCounter >= emitFrequency)
             {
                 EmitBullets();

--- a/Assets/Scripts/SlipTime.meta
+++ b/Assets/Scripts/SlipTime.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c8597e3d8ee44e3fa610cffd048c1d5e
+timeCreated: 1604986343

--- a/Assets/Scripts/SlipTime/SlipTimeAdherent.cs
+++ b/Assets/Scripts/SlipTime/SlipTimeAdherent.cs
@@ -1,0 +1,12 @@
+﻿using UnityEngine;
+
+namespace SlipTime
+{
+    /// <summary>
+    /// An object that is affected by SlipTime
+    /// </summary>
+    public class SlipTimeAdherent : MonoBehaviour
+    {
+        public float SlipTimeCoefficient { get; set; } = 1.0f;
+    }
+}

--- a/Assets/Scripts/SlipTime/SlipTimeAdherent.cs.meta
+++ b/Assets/Scripts/SlipTime/SlipTimeAdherent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec9b280a58e39014e9a3dabfab3f0eb2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SlipTime/SlipTimeManager.cs
+++ b/Assets/Scripts/SlipTime/SlipTimeManager.cs
@@ -1,0 +1,33 @@
+﻿using BulletManagement;
+using UnityEngine;
+
+namespace SlipTime
+{
+    public class SlipTimeManager : MonoBehaviour
+    {
+        private bool inSlipTime;
+        
+        // Update is called once per frame
+        private void Update()
+        {
+            if (Input.GetButtonDown("Fire2") && !inSlipTime)
+            {
+                inSlipTime = true;
+                var emitters = FindObjectsOfType<Emitter>();
+                foreach (var emitter in emitters)
+                {
+                    emitter.bulletSpeedMultiplier = new Vector3(0.25f, 0.25f, 0.25f);
+                }
+            }
+            else if (Input.GetButtonDown("Fire2") && inSlipTime)
+            {
+                inSlipTime = false;
+                var emitters = FindObjectsOfType<Emitter>();
+                foreach (var emitter in emitters)
+                {
+                    emitter.bulletSpeedMultiplier = new Vector3(1, 1, 1);
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/SlipTime/SlipTimeManager.cs
+++ b/Assets/Scripts/SlipTime/SlipTimeManager.cs
@@ -29,6 +29,7 @@ namespace SlipTime
 
         private void Update()
         {
+            // Logic for entering SlipTime
             if (Input.GetButtonDown("Fire2") && !inSlipTime)
             {
                 inSlipTime = true;
@@ -37,6 +38,8 @@ namespace SlipTime
                     slipTimeAdherent.SlipTimeCoefficient = slipTimeScalar;
                 }
             }
+            
+            // Logic for exiting SlipTime at user prompt
             else if (Input.GetButtonDown("Fire2") && inSlipTime)
             {
                 inSlipTime = false;
@@ -45,6 +48,8 @@ namespace SlipTime
                     slipTimeAdherent.SlipTimeCoefficient = 1f;
                 }
             }
+            
+            // Logic to keep track of when to exit SlipTime by default
             if (inSlipTime)
             {
                 timeCounter += Time.deltaTime;

--- a/Assets/Scripts/SlipTime/SlipTimeManager.cs
+++ b/Assets/Scripts/SlipTime/SlipTimeManager.cs
@@ -1,31 +1,61 @@
-﻿using BulletManagement;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace SlipTime
 {
+    /// <summary>
+    /// Manages activating and deactivating SlipTime.
+    /// </summary>
     public class SlipTimeManager : MonoBehaviour
     {
-        private bool inSlipTime;
+        /// <summary>
+        /// The percentage by which to scale time in SlipTime.
+        /// </summary>
+        public float slipTimeScalar = 0.25f;
         
+        /// <summary>
+        /// The default duration of SlipTime in seconds.
+        /// </summary>
+        public float slipTimeDuration = 3f;
+        
+        private bool inSlipTime;
+        private SlipTimeAdherent[] slipTimeAdherents;
+        private double timeCounter;
+
         // Update is called once per frame
+        private void Start()
+        {
+            slipTimeAdherents = FindObjectsOfType<SlipTimeAdherent>();
+        }
+
         private void Update()
         {
             if (Input.GetButtonDown("Fire2") && !inSlipTime)
             {
                 inSlipTime = true;
-                var emitters = FindObjectsOfType<Emitter>();
-                foreach (var emitter in emitters)
+                foreach (SlipTimeAdherent slipTimeAdherent in slipTimeAdherents)
                 {
-                    emitter.bulletSpeedMultiplier = new Vector3(0.25f, 0.25f, 0.25f);
+                    slipTimeAdherent.SlipTimeCoefficient = slipTimeScalar;
                 }
             }
             else if (Input.GetButtonDown("Fire2") && inSlipTime)
             {
                 inSlipTime = false;
-                var emitters = FindObjectsOfType<Emitter>();
-                foreach (var emitter in emitters)
+                foreach (SlipTimeAdherent slipTimeAdherent in slipTimeAdherents)
                 {
-                    emitter.bulletSpeedMultiplier = new Vector3(1, 1, 1);
+                    slipTimeAdherent.SlipTimeCoefficient = 1f;
+                }
+            }
+            if (inSlipTime)
+            {
+                timeCounter += Time.deltaTime;
+                if (timeCounter > slipTimeDuration)
+                {
+                    inSlipTime = false;
+                    timeCounter = 0f;
+                    foreach (SlipTimeAdherent slipTimeAdherent in slipTimeAdherents)
+                    {
+                        slipTimeAdherent.SlipTimeCoefficient = 1f;
+                    }
                 }
             }
         }

--- a/Assets/Scripts/SlipTime/SlipTimeManager.cs
+++ b/Assets/Scripts/SlipTime/SlipTimeManager.cs
@@ -18,21 +18,16 @@ namespace SlipTime
         public float slipTimeDuration = 3f;
         
         private bool inSlipTime;
-        private SlipTimeAdherent[] slipTimeAdherents;
         private double timeCounter;
-
+        
         // Update is called once per frame
-        private void Start()
-        {
-            slipTimeAdherents = FindObjectsOfType<SlipTimeAdherent>();
-        }
-
         private void Update()
         {
             // Logic for entering SlipTime
             if (Input.GetButtonDown("Fire2") && !inSlipTime)
             {
                 inSlipTime = true;
+                var slipTimeAdherents = FindObjectsOfType<SlipTimeAdherent>();
                 foreach (SlipTimeAdherent slipTimeAdherent in slipTimeAdherents)
                 {
                     slipTimeAdherent.SlipTimeCoefficient = slipTimeScalar;
@@ -43,6 +38,7 @@ namespace SlipTime
             else if (Input.GetButtonDown("Fire2") && inSlipTime)
             {
                 inSlipTime = false;
+                var slipTimeAdherents = FindObjectsOfType<SlipTimeAdherent>();
                 foreach (SlipTimeAdherent slipTimeAdherent in slipTimeAdherents)
                 {
                     slipTimeAdherent.SlipTimeCoefficient = 1f;
@@ -57,6 +53,7 @@ namespace SlipTime
                 {
                     inSlipTime = false;
                     timeCounter = 0f;
+                    var slipTimeAdherents = FindObjectsOfType<SlipTimeAdherent>();
                     foreach (SlipTimeAdherent slipTimeAdherent in slipTimeAdherents)
                     {
                         slipTimeAdherent.SlipTimeCoefficient = 1f;

--- a/Assets/Scripts/SlipTime/SlipTimeManager.cs.meta
+++ b/Assets/Scripts/SlipTime/SlipTimeManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cc34c8221dc223745b10af2def13a150
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/InputManager.asset
+++ b/ProjectSettings/InputManager.asset
@@ -204,7 +204,7 @@ InputManager:
     negativeButton: 
     positiveButton: joystick button 1
     altNegativeButton: 
-    altPositiveButton: 
+    altPositiveButton: e
     gravity: 1000
     dead: 0.001
     sensitivity: 1000


### PR DESCRIPTION
Implement `SlipTimeManager`, which allows and controls entering and exiting SlipTime.

- To enter SlipTime, play pushes the "Fire2" button (I'm reserving "Fire1" for actually shooting bullets)
- To exit SlipTime, the player may push the button again.
- SlipTime naturally exits after 3 seconds by default.