### PR TITLE
Implement v2.0 of SlipTime

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -641,8 +641,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 425, y: -262}
-  m_SizeDelta: {x: 361.7489, y: 147.12907}
+  m_AnchoredPosition: {x: 425.6, y: -227.13}
+  m_SizeDelta: {x: 361.7489, y: 145.73268}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1014272262
 MonoBehaviour:
@@ -691,7 +691,7 @@ MonoBehaviour:
     m_HorizontalOverflow: 1
     m_VerticalOverflow: 1
     m_LineSpacing: 1
-  m_Text: Slip Time Charge
+  m_Text: 'Slip Time Charges: 3'
 --- !u!222 &1014272264
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1026,10 +1026,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   slipTimeScalar: 0.25
   slipTimeCoefficient: 1
-  slipTimeDuration: 3
+  slipTimeDuration: 7
   maxSlipTimeCharges: 3
   slipTimeCharges: 0
-  slipTimeChargeDuration: 3
+  slipTimeCooldownDuration: 60
+  slipTimeMovementPenaltyCoefficient: 0.5
+  bulletGrazingCooldownDecreaseCoefficient: 0.5
 --- !u!4 &2101260597
 Transform:
   m_ObjectHideFlags: 0
@@ -1057,7 +1059,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6603763128859147253, guid: a205c73077ce14e428e9ea4efae203c1, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.030089978
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6603763128859147253, guid: a205c73077ce14e428e9ea4efae203c1, type: 3}
       propertyPath: m_LocalPosition.y
@@ -1095,6 +1097,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6603763129029014502, guid: a205c73077ce14e428e9ea4efae203c1, type: 3}
+      propertyPath: slipTimeManager
+      value: 
+      objectReference: {fileID: 2101260596}
     - target: {fileID: 6603763129383013086, guid: a205c73077ce14e428e9ea4efae203c1, type: 3}
       propertyPath: bulletPrefab
       value: 

--- a/Assets/Scripts/Actor/Shield.cs
+++ b/Assets/Scripts/Actor/Shield.cs
@@ -1,15 +1,17 @@
-﻿using System;
+﻿using SlipTime;
 using UnityEngine;
 
 namespace Actor
 {
     public class Shield : MonoBehaviour
     {
+        public SlipTimeManager slipTimeManager;
+        
         private void OnTriggerEnter2D(Collider2D other)
         {
             if (other.gameObject.layer == 10)
             {
-                Debug.Log("Shields holding!");
+                slipTimeManager.DecreaseCooldown();
             }
         }
     }

--- a/Assets/Scripts/BulletManagement/PlayerEmitter.cs
+++ b/Assets/Scripts/BulletManagement/PlayerEmitter.cs
@@ -7,7 +7,7 @@ namespace BulletManagement
         // For playing bullet animations and audio fx
         public Animator animator;
 
-        protected void Start()
+        protected new void Start()
         {
             base.Start();
             animator = transform.parent.gameObject.GetComponent<Animator>();

--- a/Assets/Scripts/BulletManagement/SlipTimeEmitter.cs
+++ b/Assets/Scripts/BulletManagement/SlipTimeEmitter.cs
@@ -39,7 +39,7 @@ namespace BulletManagement
         // Determines if the emitter should aim at the player or not. Note that this will overwrite startAngle.
         public bool aimed = false;
 
-        void Start()
+        private new void Start()
         {
             limited = emitCycles != 0;
             this.bulletPattern = this.GetComponent<BulletPattern>();

--- a/Assets/Scripts/SlipTime/SlipTimeManager.cs
+++ b/Assets/Scripts/SlipTime/SlipTimeManager.cs
@@ -133,7 +133,7 @@ namespace SlipTime
         }
 
         /// <summary>
-        /// Decrease the current cooldown of SlipTime by the given amount.
+        /// Decrease the current cooldown of SlipTime.
         /// </summary>
         public void DecreaseCooldown()
         {

--- a/Assets/Scripts/SlipTime/SlipTimeManager.cs
+++ b/Assets/Scripts/SlipTime/SlipTimeManager.cs
@@ -20,13 +20,13 @@ namespace SlipTime
         /// <summary>
         /// The default duration of SlipTime in seconds.
         /// </summary>
-        public float slipTimeDuration = 3f;
+        public float slipTimeDuration = 7f;
 
         /// <summary>
         /// The maximum number of charges of SlipTime a player can have.
         /// </summary>
         public int maxSlipTimeCharges = 3;
-        
+
         /// <summary>
         /// The number of SlipTime charges the player currently has.
         /// </summary>
@@ -36,56 +36,110 @@ namespace SlipTime
         /// <summary>
         /// The default amount of time it takes to charge one charge of SlipTime.
         /// </summary>
-        public float slipTimeChargeDuration = 3;
+        public float slipTimeCooldownDuration = 60f;
 
-        private bool inSlipTime;
-        private double slipTimeCounter;
-        private double chargeTimeCounter;
+        /// <summary>
+        /// How much SlipTime duration to subtract if the player moves during SlipTime.
+        /// </summary>
+        public float slipTimeMovementPenaltyCoefficient = 0.5f;
+
+        /// <summary>
+        /// The default amount of time to decrease the current cooldown of SlipTime by when bullet grazing.
+        /// </summary>
+        public float bulletGrazingCooldownDecreaseCoefficient = 0.5f;
+
+        /// <summary>
+        /// Counter to keep track of time spent in SlipTime.
+        /// </summary>
+        public float SlipTimeCounter { get; private set; }
+
+        /// <summary>
+        /// Counter to keep track of time spent charging SlipTime.
+        /// </summary>
+        public float ChargeTimeCounter { get; private set; }
+
+        /// <summary>
+        /// Whether the player is in SlipTime.
+        /// </summary>
+        public bool InSlipTime { get; private set; }
+
+        /// <summary>
+        /// Whether the player is charging a charge of SlipTime.
+        /// </summary>
+        public bool IsChargingSlipTime { get; private set; }
 
         private void Start()
         {
             slipTimeCharges = maxSlipTimeCharges;
+            InSlipTime = false;
+            IsChargingSlipTime = false;
+            SlipTimeCounter = slipTimeDuration;
+            ChargeTimeCounter = slipTimeCooldownDuration;
         }
 
-        // Update is called once per frame
+        // Update is called once per frame.
         private void Update()
         {
-            // Logic for entering SlipTime
-            if (Input.GetButtonDown("Fire2") && !inSlipTime && slipTimeCharges > 0)
+            // Logic for entering SlipTime.
+            if (Input.GetButtonDown("Fire2") && !InSlipTime && slipTimeCharges > 0)
             {
-                inSlipTime = true;
+                InSlipTime = true;
                 slipTimeCoefficient = slipTimeScalar;
                 slipTimeCharges -= 1;
             }
 
-            // Logic for exiting SlipTime at user prompt
-            else if (Input.GetButtonDown("Fire2") && inSlipTime)
+            // Logic for exiting SlipTime at user prompt.
+            else if (Input.GetButtonDown("Fire2") && InSlipTime)
             {
-                inSlipTime = false;
-                slipTimeCounter = 0f;
+                InSlipTime = false;
+                SlipTimeCounter = slipTimeDuration;
                 slipTimeCoefficient = 1f;
+                IsChargingSlipTime = true;
             }
 
-            // Logic to keep track of when to exit SlipTime by default
-            if (inSlipTime)
+            // Logic to decrease the active SlipTime duration if the player moves.
+            if (Input.GetButton("Horizontal") || Input.GetButton("Vertical") && InSlipTime)
             {
-                slipTimeCounter += Time.deltaTime;
-                if (slipTimeCounter > slipTimeDuration)
+                SlipTimeCounter -= Time.deltaTime * slipTimeMovementPenaltyCoefficient;
+            }
+
+            // Logic to keep track of when to exit SlipTime by default.
+            if (InSlipTime)
+            {
+                SlipTimeCounter -= Time.deltaTime;
+                if (SlipTimeCounter <= 0)
                 {
-                    inSlipTime = false;
-                    slipTimeCounter = 0f;
+                    InSlipTime = false;
+                    SlipTimeCounter = slipTimeDuration;
                     slipTimeCoefficient = 1f;
+                    IsChargingSlipTime = true;
                 }
             }
 
-            if (slipTimeCharges < maxSlipTimeCharges && (slipTimeCharges != maxSlipTimeCharges - 1 || !inSlipTime))
+            // Logic to handle the cooldown of SlipTime charges.
+            if (IsChargingSlipTime)
             {
-                chargeTimeCounter += Time.deltaTime;
-                if (chargeTimeCounter >= slipTimeChargeDuration)
+                ChargeTimeCounter -= Time.deltaTime;
+                if (ChargeTimeCounter <= 0)
                 {
                     slipTimeCharges += 1;
-                    chargeTimeCounter = 0f;
+                    ChargeTimeCounter = slipTimeCooldownDuration;
+                    if (slipTimeCharges == maxSlipTimeCharges)
+                    {
+                        IsChargingSlipTime = false;
+                    }
                 }
+            }
+        }
+
+        /// <summary>
+        /// Decrease the current cooldown of SlipTime by the given amount.
+        /// </summary>
+        public void DecreaseCooldown()
+        {
+            if (slipTimeCharges < maxSlipTimeCharges)
+            {
+                ChargeTimeCounter -= Time.deltaTime * bulletGrazingCooldownDecreaseCoefficient;
             }
         }
     }

--- a/Assets/Scripts/UI/SlipTimeUI.cs
+++ b/Assets/Scripts/UI/SlipTimeUI.cs
@@ -1,6 +1,6 @@
-﻿using SlipTime;
+﻿using System;
+using SlipTime;
 using UnityEngine;
-using UnityEngine.Serialization;
 using UnityEngine.UI;
 
 namespace UI
@@ -8,26 +8,42 @@ namespace UI
     public class SlipTimeUI : MonoBehaviour
     {
         public SlipTimeManager slipTimeManager;
-    
+
         public Text slipTimeUIText;
 
         private int slipTimeCharges;
 
         // Start is called before the first frame update
-        void Start()
+        private void Start()
         {
             slipTimeCharges = slipTimeManager.slipTimeCharges;
             slipTimeUIText.text = $"Slip Time Charges: {slipTimeCharges}";
         }
 
         // Update is called once per frame
-        void Update()
+        private void Update()
         {
-            if (slipTimeCharges != slipTimeManager.slipTimeCharges)
+            var slipTimeText = $"Slip Time Charges: {slipTimeManager.slipTimeCharges}";
+            
+            // Leave this code here for now. We may be able to re-use it later once we get a better UI for SlipTime
+            // if we don't have to constantly update the text box. If this comment is confusing, talk to NLow.
+            // if (slipTimeCharges != slipTimeManager.slipTimeCharges)
+            // {
+            //     slipTimeCharges = slipTimeManager.slipTimeCharges;
+            //     slipTimeUIText.text = $"Slip Time Charges: {slipTimeCharges}";
+            // }
+
+            if (slipTimeManager.InSlipTime)
             {
-                slipTimeCharges = slipTimeManager.slipTimeCharges;
-                slipTimeUIText.text = $"Slip Time Charges: {slipTimeCharges}";
+                slipTimeText += $"\nSlip Time Duration: {Convert.ToInt32(slipTimeManager.SlipTimeCounter)}";
             }
+
+            if (slipTimeManager.IsChargingSlipTime)
+            {
+                slipTimeText += $"\nSlip Time Cooldown: {Convert.ToInt32(slipTimeManager.ChargeTimeCounter)}";
+            }
+
+            slipTimeUIText.text = slipTimeText;
         }
     }
 }

--- a/Assets/Scripts/UI/SlipTimeUI.cs
+++ b/Assets/Scripts/UI/SlipTimeUI.cs
@@ -26,7 +26,7 @@ namespace UI
             var slipTimeText = $"Slip Time Charges: {slipTimeManager.slipTimeCharges}";
             
             // Leave this code here for now. We may be able to re-use it later once we get a better UI for SlipTime
-            // if we don't have to constantly update the text box. If this comment is confusing, talk to NLow.
+            // if we don't have to constantly update the text box.
             // if (slipTimeCharges != slipTimeManager.slipTimeCharges)
             // {
             //     slipTimeCharges = slipTimeManager.slipTimeCharges;


### PR DESCRIPTION
Updated duration and cooldown lengths.
Bullet grazing decreases the cooldown.
Moving decreases the duration.

I've also implemented a rudimentary GUI that displays the duration and cooldown values below the display of SlipTime charges. Note that this is not a final GUI and should be updated in the [SlipTime GUI ticket](https://trello.com/c/rcSOP5Wj).